### PR TITLE
Fixed a bug where circle angle property resets to 0 after first element when applying warp to multiple elements

### DIFF
--- a/src/csswarp.0.3.1.js
+++ b/src/csswarp.0.3.1.js
@@ -330,15 +330,15 @@
  					
  				if(circle.angle){
  					if(!/rad/gi.test(THIS.config.path.angle)){
- 						circle.angle = parseFloat(circle.angle) * Math.PI/180;
+ 						circle.calculatedAngle = parseFloat(circle.angle) * Math.PI/180;
  					}else{
- 						circle.angle = parseFloat(circle.angle);
+ 						circle.calculatedAngle = parseFloat(circle.angle);
  					}
  				}else{
- 					circle.angle = 0;
+ 					circle.calculatedAngle = 0;
  				}
  					
- 				circle.angle-= Math.PI/2;
+ 				circle.calculatedAngle-= Math.PI/2;
  				
  				switch(circle.textPosition){
  					case "inside":
@@ -363,7 +363,7 @@
  				}
  
   				function polarCoords(arc){
-  					var angle = arc/circle.radius+circle.angle,
+  					var angle = arc/circle.radius+circle.calculatedAngle,
   						cos = Math.cos(angle),
   						sin = Math.sin(angle),
   						x	= circle.radius*cos+circle.center[0],


### PR DESCRIPTION
Instead of overwriting the circle.angle property with the calculated radian angle, the code should add a new property to keep the original angle property unaffected.

Not sure how it should be minified, so I'll leave that to you or someone else.

The code that triggered the bug for me:

``` javascript
  cssWarp({
    path: {
      radius: 60,
      angle: '180deg'
    },
    targets: '.someclass'
  });
```

The first target used the correct angle of 180deg, but following targets reverted to angle of 0 (or close to it), because the angle was rewritten in radians and then re-interpreted as degrees.
