### PR TITLE
I was occasionally seeing weird baseline calculations in firefox that would then position the text wrongly

### DIFF
--- a/src/csswarp.0.6.js
+++ b/src/csswarp.0.6.js
@@ -542,20 +542,18 @@
 			
 		function calcBaseline(){
 				var testDiv = document.createElement("div"),
-					img = document.createElement("img"),
+					span = document.createElement("span"),
 					lineHeight = getStyle(node, "lineHeight"),
 					base;
 					
-				img.width = 1;
-				img.height = 1;
-				img.src = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
-				img.style.verticalAlign = "baseline";
-				img.style.display = "inline";	
+				span.innerHTML = 'A';
+				span.style.verticalAlign = "baseline";
+				span.style.fontSize = "0px";
 				testDiv.style.cssText = baseCSS+'height:'+letters[0].height+';line-height:'+lineHeight+'px;';
 				testDiv.innerHTML="M";
-				testDiv.appendChild(img);
+				testDiv.appendChild(span);
 				node.appendChild(testDiv);
-				base = img.offsetTop;
+				base = span.offsetTop;
 				node.removeChild(testDiv);
 				return base;
 		}


### PR DESCRIPTION
After a lot of debugging it seemed to come down to a strange situation in Firefox where the img.offsetTop property wouldn't be accurate immediately after it was appended to the dom, but would be updated if given a chance. Might have been some sort of threading issue? If you stepped through everything it worked fine, but running over the code and breaking on the next line produced this weirdness:

![Screen Shot 2013-04-26 at 3 35 18 PM](https://f.cloud.github.com/assets/79998/433114/eb2cd5e0-aebc-11e2-9771-9dac7eb1b36c.png)

I tried replacing the inserted img tag with a span to see if that would solve the problem and it seemed to. I also use font-size: 0px instead of img.height = 1, which should result in a 1px more accurate baseline reading.
